### PR TITLE
Add basic board and player movement

### DIFF
--- a/src/components/Board/Board.ts
+++ b/src/components/Board/Board.ts
@@ -1,0 +1,115 @@
+import Phaser from 'phaser';
+import { CellPosition } from './types';
+
+export class Board {
+  private scene: Phaser.Scene;
+  readonly rows: number;
+  readonly cols: number;
+  readonly cellSize: number;
+  private cells: Phaser.GameObjects.Rectangle[][] = [];
+
+  constructor(scene: Phaser.Scene, rows: number, cols: number, cellSize: number) {
+    this.scene = scene;
+    this.rows = rows;
+    this.cols = cols;
+    this.cellSize = cellSize;
+    this.create();
+  }
+
+  private create() {
+    const graphics = this.scene.add.graphics();
+    graphics.lineStyle(1, 0xffffff, 0.3);
+    for (let r = 0; r < this.rows; r++) {
+      this.cells[r] = [];
+      for (let c = 0; c < this.cols; c++) {
+        const x = c * this.cellSize;
+        const y = r * this.cellSize + 50; // offset for UI
+        const rect = this.scene.add
+          .rectangle(x + this.cellSize / 2, y + this.cellSize / 2, this.cellSize, this.cellSize)
+          .setStrokeStyle(1, 0xffffff, 0.2)
+          .setOrigin(0.5)
+          .setInteractive();
+        this.cells[r][c] = rect as Phaser.GameObjects.Rectangle;
+      }
+    }
+    for (let r = 0; r <= this.rows; r++) {
+      graphics.moveTo(0, 50 + r * this.cellSize);
+      graphics.lineTo(this.cols * this.cellSize, 50 + r * this.cellSize);
+    }
+    for (let c = 0; c <= this.cols; c++) {
+      graphics.moveTo(c * this.cellSize, 50);
+      graphics.lineTo(c * this.cellSize, 50 + this.rows * this.cellSize);
+    }
+    graphics.strokePath();
+  }
+
+  getCell(pos: CellPosition): Phaser.GameObjects.Rectangle {
+    return this.cells[pos.row][pos.col];
+  }
+
+  worldPosition(pos: CellPosition): { x: number; y: number } {
+    return {
+      x: pos.col * this.cellSize + this.cellSize / 2,
+      y: 50 + pos.row * this.cellSize + this.cellSize / 2,
+    };
+  }
+
+  computePath(start: CellPosition, end: CellPosition): CellPosition[] {
+    const queue: CellPosition[] = [start];
+    const visited = new Set<string>();
+    const parent = new Map<string, CellPosition | null>();
+    const key = (p: CellPosition) => `${p.row},${p.col}`;
+    visited.add(key(start));
+    parent.set(key(start), null);
+    const dirs = [
+      { r: 1, c: 0 },
+      { r: -1, c: 0 },
+      { r: 0, c: 1 },
+      { r: 0, c: -1 },
+      { r: 1, c: 1 },
+      { r: 1, c: -1 },
+      { r: -1, c: 1 },
+      { r: -1, c: -1 },
+    ];
+    while (queue.length) {
+      const cur = queue.shift()!;
+      if (cur.row === end.row && cur.col === end.col) break;
+      for (const d of dirs) {
+        const nr = cur.row + d.r;
+        const nc = cur.col + d.c;
+        if (nr < 0 || nr >= this.rows || nc < 0 || nc >= this.cols) continue;
+        const n: CellPosition = { row: nr, col: nc };
+        const k = key(n);
+        if (!visited.has(k)) {
+          visited.add(k);
+          parent.set(k, cur);
+          queue.push(n);
+        }
+      }
+    }
+    const path: CellPosition[] = [];
+    let current: CellPosition | undefined = end;
+    while (current) {
+      path.unshift(current);
+      const p = parent.get(key(current));
+      if (!p) break;
+      current = p;
+    }
+    return path;
+  }
+
+  clearHighlight() {
+    for (let r = 0; r < this.rows; r++) {
+      for (let c = 0; c < this.cols; c++) {
+        this.cells[r][c].setFillStyle();
+      }
+    }
+  }
+
+  highlightPath(path: CellPosition[], color: number) {
+    this.clearHighlight();
+    path.forEach((p) => {
+      this.getCell(p).setFillStyle(color, 0.5);
+    });
+  }
+}

--- a/src/components/Board/index.ts
+++ b/src/components/Board/index.ts
@@ -1,0 +1,2 @@
+export { Board } from './Board';
+export type { CellPosition } from './types';

--- a/src/components/Board/types.ts
+++ b/src/components/Board/types.ts
@@ -1,0 +1,4 @@
+export interface CellPosition {
+  row: number;
+  col: number;
+}

--- a/src/components/Entities/Entity.ts
+++ b/src/components/Entities/Entity.ts
@@ -1,0 +1,21 @@
+import Phaser from 'phaser';
+import { Board, CellPosition } from '../Board';
+
+export class Entity {
+  protected scene: Phaser.Scene;
+  position: CellPosition;
+  protected display: Phaser.GameObjects.Text;
+
+  constructor(scene: Phaser.Scene, board: Board, position: CellPosition, char: string) {
+    this.scene = scene;
+    this.position = position;
+    const { x, y } = board.worldPosition(position);
+    this.display = scene.add.text(x, y, char, { fontSize: '24px', color: '#ff0000' }).setOrigin(0.5);
+  }
+
+  moveTo(board: Board, pos: CellPosition) {
+    this.position = pos;
+    const { x, y } = board.worldPosition(pos);
+    this.display.setPosition(x, y);
+  }
+}

--- a/src/components/Entities/Player.ts
+++ b/src/components/Entities/Player.ts
@@ -1,0 +1,31 @@
+import { Board, CellPosition } from '../Board';
+import { Entity } from './Entity';
+
+export class Player extends Entity {
+  movePoints: number;
+
+  constructor(scene: Phaser.Scene, board: Board, position: CellPosition, move = 5) {
+    super(scene, board, position, 'X');
+    this.movePoints = move;
+  }
+
+  async moveAlong(board: Board, path: CellPosition[]): Promise<void> {
+    const duration = 150;
+    for (let i = 1; i < path.length; i++) {
+      await new Promise<void>((resolve) => {
+        const pos = path[i];
+        const { x, y } = board.worldPosition(pos);
+        this.scene.tweens.add({
+          targets: this.display,
+          x,
+          y,
+          duration,
+          onComplete: () => {
+            this.position = pos;
+            resolve();
+          },
+        });
+      });
+    }
+  }
+}

--- a/src/components/Entities/index.ts
+++ b/src/components/Entities/index.ts
@@ -1,0 +1,2 @@
+export { Entity } from './Entity';
+export { Player } from './Player';

--- a/src/components/Turn/TurnManager.ts
+++ b/src/components/Turn/TurnManager.ts
@@ -1,0 +1,11 @@
+export class TurnManager {
+  private _turn = 0;
+
+  get turn() {
+    return this._turn;
+  }
+
+  nextTurn() {
+    this._turn += 1;
+  }
+}

--- a/src/components/Turn/index.ts
+++ b/src/components/Turn/index.ts
@@ -1,0 +1,1 @@
+export { TurnManager } from './TurnManager';

--- a/src/components/UI/StepCounter.ts
+++ b/src/components/UI/StepCounter.ts
@@ -1,0 +1,16 @@
+import Phaser from 'phaser';
+
+export class StepCounter {
+  private text: Phaser.GameObjects.Text;
+
+  constructor(scene: Phaser.Scene) {
+    this.text = scene.add.text(10, 10, '0', {
+      fontSize: '32px',
+      color: '#ffffff',
+    });
+  }
+
+  update(turn: number) {
+    this.text.setText(String(turn));
+  }
+}

--- a/src/components/UI/index.ts
+++ b/src/components/UI/index.ts
@@ -1,0 +1,1 @@
+export { StepCounter } from './StepCounter';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,6 @@
+export const BOARD_ROWS = 15;
+export const BOARD_COLS = 15;
+export const CELL_SIZE = 32;
+
+export const GAME_WIDTH = BOARD_COLS * CELL_SIZE;
+export const GAME_HEIGHT = BOARD_ROWS * CELL_SIZE + 50; // extra for UI

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
 import Phaser from 'phaser';
+import { GAME_WIDTH, GAME_HEIGHT } from './config';
+import { BootScene } from './scenes/BootScene';
+import { PreloadScene } from './scenes/PreloadScene';
+import { GameScene } from './scenes/GameScene';
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
-  width: 800,
-  height: 600,
-  scene: [],
+  width: GAME_WIDTH,
+  height: GAME_HEIGHT,
+  scene: [BootScene, PreloadScene, GameScene],
 };
 
 new Phaser.Game(config);

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,0 +1,11 @@
+import Phaser from 'phaser';
+
+export class BootScene extends Phaser.Scene {
+  constructor() {
+    super('BootScene');
+  }
+
+  create() {
+    this.scene.start('PreloadScene');
+  }
+}

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,0 +1,60 @@
+import Phaser from 'phaser';
+import { BOARD_ROWS, BOARD_COLS, CELL_SIZE } from '../config';
+import { Board, CellPosition } from '../components/Board';
+import { Player } from '../components/Entities';
+import { TurnManager } from '../components/Turn';
+import { StepCounter } from '../components/UI';
+
+export class GameScene extends Phaser.Scene {
+  private board!: Board;
+  private player!: Player;
+  private turnManager = new TurnManager();
+  private counter!: StepCounter;
+  private currentPath: CellPosition[] = [];
+
+  constructor() {
+    super('GameScene');
+  }
+
+  create() {
+    this.board = new Board(this, BOARD_ROWS, BOARD_COLS, CELL_SIZE);
+    const startPos: CellPosition = { row: BOARD_ROWS - 1, col: Math.floor(BOARD_COLS / 2) };
+    this.player = new Player(this, this.board, startPos, 5);
+    this.counter = new StepCounter(this);
+
+    for (let r = 0; r < BOARD_ROWS; r++) {
+      for (let c = 0; c < BOARD_COLS; c++) {
+        const cellPos = { row: r, col: c };
+        const cell = this.board.getCell(cellPos);
+        cell.on('pointerover', () => this.onCellOver(cellPos));
+        cell.on('pointerout', () => this.onCellOut());
+        cell.on('pointerdown', () => this.onCellDown(cellPos));
+      }
+    }
+  }
+
+  private onCellOver(pos: CellPosition) {
+    const path = this.board.computePath(this.player.position, pos);
+    this.currentPath = path;
+    const reachable = path.length - 1 <= this.player.movePoints;
+    const color = reachable ? 0x00ff00 : 0x888888;
+    this.board.highlightPath(path, color);
+  }
+
+  private onCellOut() {
+    this.board.clearHighlight();
+    this.currentPath = [];
+  }
+
+  private async onCellDown(pos: CellPosition) {
+    const path = this.board.computePath(this.player.position, pos);
+    if (path.length - 1 > this.player.movePoints) return;
+    this.board.highlightPath(path, 0x00ff00);
+    this.input.enabled = false;
+    await this.player.moveAlong(this.board, path);
+    this.turnManager.nextTurn();
+    this.counter.update(this.turnManager.turn);
+    this.input.enabled = true;
+    this.board.clearHighlight();
+  }
+}

--- a/src/scenes/PreloadScene.ts
+++ b/src/scenes/PreloadScene.ts
@@ -1,0 +1,15 @@
+import Phaser from 'phaser';
+
+export class PreloadScene extends Phaser.Scene {
+  constructor() {
+    super('PreloadScene');
+  }
+
+  preload() {
+    // assets would be loaded here
+  }
+
+  create() {
+    this.scene.start('GameScene');
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "lib": ["es2015", "dom"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- set up board, entity, turn and UI components
- add player entity with simple movement
- add basic scenes and config
- implement GameScene with board and player interaction
- update TypeScript config for ES2015 libs

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d4caae9b8832eb0fd5e5dbf5b1dac